### PR TITLE
Import matching settings json file data into dashboard if it exists

### DIFF
--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -26,6 +26,7 @@ module.exports.Dashing = function Dashing() {
 
   dashing.public_folder = dashing.root + '/public';
   dashing.views = dashing.root + '/dashboards';
+  dashing.settings = dashing.root + '/settings';
   dashing.default_dashboard = null;
   dashing.port = (process.env.PORT || 3030);
 
@@ -130,9 +131,16 @@ module.exports.Dashing = function Dashing() {
     var dashboard = req.params.dashboard;
     fs.exists([dashing.views, dashboard + '.' + dashing.view_engine].join(path.sep), function(exists) {
       if (exists) {
-        res.render(dashboard, {
+        var templateVars = {
           dashboard: dashboard,
           request: req
+        };
+        var settingsPath = [dashing.settings, dashboard + '.json'].join(path.sep);
+        fs.exists(settingsPath, function(exists) {
+          if (exists) {
+            templateVars.settings = require(settingsPath);
+          }
+          res.render(dashboard, templateVars);
         });
       } else {
         res.status(404).sendfile(dashing.public_folder + '/404.html');


### PR DESCRIPTION
If our dashboard template is named acme.jade, then look for a settings file called settings/acme.json and import that data into the template.
