### PR TITLE
empty event history causes new /events requests to fail

### DIFF
--- a/lib/dashing.js
+++ b/lib/dashing.js
@@ -103,8 +103,11 @@ module.exports.Dashing = function Dashing() {
     res.write('\n');
     res.write(Array(2049).join(' ') + '\n'); // 2kb padding for IE
     latest_events()
-      .done( function(events) {
-        res.write(events);
+      .then( function(events) {
+        if(events) {
+          res.write(events);
+        }
+      }).done(function() {
         res.flush(); // need to flush with .compress()
       });
 
@@ -190,7 +193,8 @@ module.exports.Dashing = function Dashing() {
   }
 
   function latest_events() {
-    return Promise.resolve(dashing.history.getAll()) // assure trusted promise
+    return Promise
+      .resolve(dashing.history.getAll()) // assure trusted promise
       .reduce( function(agg, next) {
         return agg + next; 
       });
@@ -223,6 +227,7 @@ module.exports.Dashing = function Dashing() {
   function start_jobs() {
     // Load jobs files
     var job_path = process.env.JOB_PATH || [dashing.root, 'jobs'].join(path.sep);
+    logger.info('Searching for jobs in', job_path);
     fs.readdir(job_path, function(err, files) {
       if (err) throw err;
       for (var i in files) {

--- a/lib/inMemoryHistory.js
+++ b/lib/inMemoryHistory.js
@@ -21,7 +21,7 @@ var InMemoryHistory = module.exports = function() {
         return self._event_data[key];
       });
 
-    return new Promise.resolve(values);
+    return Promise.resolve(values);
   };
 
   return self;


### PR DESCRIPTION
During the opening request to `/events` we pull the latest history and
attempt to push it to the client before future events are dispatched
live.  If we had no history, as the default InMemoryHistory would not,
the request through an error.
